### PR TITLE
Update zlib version in prereq_install.sh

### DIFF
--- a/Tools/Scripts/prereq_install.sh
+++ b/Tools/Scripts/prereq_install.sh
@@ -27,7 +27,7 @@
 netcdf_c_ver=4.9.2
 netcdf_f_ver=4.6.1
 hdf5_ver=1.14.2
-zlib_ver=1.3
+zlib_ver=1.3.1
 ompi_ver=4.1.6
 ompi_major=`echo $ompi_ver | cut -d "." -f 1-2`
 hdf5_major=`echo $hdf5_ver | cut -d "." -f 1-2`


### PR DESCRIPTION
The default `zlib_ver=1.3` generates the following URL when loading zlib: http://zlib.net/zlib-1.3.tar.gz 
However, it returns a 404 as of 22/1/24
Slight change to:
`zlib_ver=1.3.1`
http://zlib.net/zlib-1.3.1.tar.gz 
fixes the issue