### PR TITLE
Speed-dependent Charnock parameter in COARE3.0?

### DIFF
--- a/Main/ocnlib/mod_ocn_coare.F90
+++ b/Main/ocnlib/mod_ocn_coare.F90
@@ -54,6 +54,7 @@ module mod_ocn_coare
       real(rkx) :: l , Bf , tkt , qout , qcol , alq , xlamx , dqer
       real(rkx) :: le , visa , rhoa , cpv , Rns , Rnl
       real(rkx) :: hsb , hlb , tau , uv10 , facttq
+      real(rkx) :: charnock
       integer(ik4) :: i , k , niter
       logical :: iflag
 
@@ -92,6 +93,15 @@ module mod_ocn_coare
         zu = z995
         zt = z995
         zq = z995
+
+        ! speed-dependent Charnock parameter
+        if (uv995 < 10_rkx) then
+          charnock = 0.011_rkx
+        else if (uv995 > 18_rkx) then
+          charnock = 0.018_rkx
+        else
+          charnock = 0.011_rkx + (0.018_rkx - 0.011_rkx)*(uv995 - 10_rkx)/(18_rkx - 10_rkx)
+        end if
 
         ! height (m) of atmospheric boundary layer
         zi = hpbl(i)
@@ -172,7 +182,7 @@ module mod_ocn_coare
         if ( iflag ) then
           zo10 = zogs
         else
-          zo10 = 0.011_rkx*usr*usr*regrav+0.11_rkx*visa/usr
+          zo10 = charnock*usr*usr*regrav+0.11_rkx*visa/usr
         end if
 
         ! initial guess for drag coefficents
@@ -222,7 +232,7 @@ module mod_ocn_coare
           if ( iflag ) then
             zo = zogs
           else
-            zo = 0.011_rkx*usr*usr*regrav+0.11_rkx*visa/usr
+            zo = charnock*usr*usr*regrav+0.11_rkx*visa/usr
           end if
 
           rr = zo*usr/visa

--- a/Main/ocnlib/mod_ocn_coare.F90
+++ b/Main/ocnlib/mod_ocn_coare.F90
@@ -93,16 +93,6 @@ module mod_ocn_coare
         zu = z995
         zt = z995
         zq = z995
-
-        ! speed-dependent Charnock parameter
-        if (uv995 < 10_rkx) then
-          charnock = 0.011_rkx
-        else if (uv995 > 18_rkx) then
-          charnock = 0.018_rkx
-        else
-          charnock = 0.011_rkx + (0.018_rkx - 0.011_rkx)*(uv995 - 10_rkx)/(18_rkx - 10_rkx)
-        end if
-
         ! height (m) of atmospheric boundary layer
         zi = hpbl(i)
         !
@@ -130,6 +120,15 @@ module mod_ocn_coare
           Al = 2.1e-5_rkx*(ts+3.2_rkx)**0.79_rkx
         else
           Al = 2.4253e-05_rkx
+        end if
+
+        ! speed-dependent Charnock parameter
+        if (uv995 < 10_rkx) then
+          charnock = 0.011_rkx
+        else if (uv995 > 18_rkx) then
+          charnock = 0.018_rkx
+        else
+          charnock = 0.011_rkx + (0.018_rkx - 0.011_rkx)*(uv995 - 10_rkx)/(18_rkx - 10_rkx)
         end if
         !
         !-----------------------------------------------------


### PR DESCRIPTION
Hello Graziano,

In COARE3.0, is this normal that the speed-dependent Charnock parameter of Fairall et al. (2003) is not applied? They wrote in the article "*alpha increases linearly from 0.011 at U_{10n} = 10ms^{-1} to 0.018 at U_{10n} = 18 ms^{-1}, and remains constant for lack of better information beyond this wind speed.*"

If ignoring this is not intended, I propose the simple modifications below. It compiles and works normally. In a short test I made over the Philippine Sea throughout September to get some tropical cyclone passing by, I compared with and without the speed-dependent Charnock parameter and it gave the figure below comparing the surface wind stress of SRF outputs (speed-dependent in the bottom pannel), where the highest wind stress is about 10% higher near the eye. It should make a difference in coupled experiments, I guess.

![COARE3](https://github.com/ICTP/RegCM/assets/99653227/6df68a83-4613-491d-9ede-45c0793a9097)

Cheers,
Quentin

**References**

Fairall, C.W., Bradley, E.F., Hare, J.E., Grachev, A.A., Edson, J.B., 2003. Bulk Parameterization of Air–Sea Fluxes: Updates and Verification for the COARE Algorithm. Journal of Climate 16, 571–591. DOI:[10.1175/1520-0442(2003)016<0571:BPOASF>2.0.CO;2](https://doi.org/10.1175/1520-0442(2003)016<0571:BPOASF>2.0.CO;2)