### PR TITLE
Can't download zlib through prereq_install.sh

### DIFF
--- a/Tools/Scripts/prereq_install.sh
+++ b/Tools/Scripts/prereq_install.sh
@@ -27,7 +27,7 @@
 netcdf_c_ver=4.9.2
 netcdf_f_ver=4.6.1
 hdf5_ver=1.14.1-2
-zlib_ver=1.2.13
+zlib_ver=1.3.1
 ompi_ver=4.1.5
 ompi_major=`echo $ompi_ver | cut -d "." -f 1-2`
 hdf5_major=`echo $hdf5_ver | cut -d "." -f 1-2`


### PR DESCRIPTION
Old version of zlib in prereq_install.sh (ISC24 branch) that can no longer be downloaded

(Was already fixed in master branch)