### PR TITLE
fix: syntax for backward compiler compatibility

### DIFF
--- a/Share/mod_projections.F90
+++ b/Share/mod_projections.F90
@@ -85,7 +85,8 @@ module mod_projections
       procedure , public :: wind2_rotate
       procedure , public :: wind_antirotate
       procedure , public :: wind2_antirotate
-      procedure , public :: rl00 , conefac
+      procedure , public :: rl00
+      procedure , public :: conefac
       procedure , public :: destruct
 
   end type regcm_projection


### PR DESCRIPTION
I don't know if you care, but I happened to compile the model with the following "old" modules:

```bash
Currently Loaded Modulefiles:
  1) intel/14.0.1.106     2) intel_netcdf/4.4.5     3) intel_ompi/1.10.6
```

And it didn't make it for this single line.

```bash
mod_projections.F90(88): error #8259: The type bound procedure definition statement must contains only one binding name.   [CONEFAC]
      procedure , public :: rl00 , conefac
-----------------------------------^
```

It seemed safer to break it into two lines...
