### PR TITLE
Optimizing OASIS calls timings

### DIFF
--- a/Main/mod_regcm_interface.F90
+++ b/Main/mod_regcm_interface.F90
@@ -150,12 +150,6 @@ module mod_regcm_interface
     !
 #ifdef OASIS
     if ( ioasiscpl == 1 ) then
-#ifdef DEBUG
-      !
-      ! OASIS Log Files Setup
-      !
-      !call oasisxregcm_open_log(comp_name,comp_id)
-#endif
       !
       ! OASIS Variables Setup
       !
@@ -363,12 +357,6 @@ module mod_regcm_interface
       ! OASIS Variables Release
       !
       call oasisxregcm_release
-#ifdef DEBUG
-      !
-      ! OASIS Log Files Closing
-      !
-      !call oasisxregcm_close_log
-#endif
     end if
 #endif
 

--- a/Main/mod_regcm_interface.F90
+++ b/Main/mod_regcm_interface.F90
@@ -263,10 +263,6 @@ module mod_regcm_interface
         call tend
       end if
       !
-      ! Write output for this timestep if requested
-      !
-      call output
-      !
       ! Send OASIS fields
       !
 #ifdef OASIS
@@ -277,6 +273,10 @@ module mod_regcm_interface
         end if
       end if
 #endif
+      !
+      ! Write output for this timestep if requested
+      !
+      call output
       !
       ! Boundary code
       !


### PR DESCRIPTION
Hi Graziano! A small update for the OASIS interface

Sending through OASIS is quick and non-blocking, thus it should be done as soon as possible.
(Receiving from OASIS is blocking, i.e., RegCM would wait for the other components, thus on the contrary, we should receive the fields as late as possible, but it's already this way in the code).

Cheers