### PR TITLE
Pnetcdf build adjustment

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -398,7 +398,7 @@ AC_DEFUN([AX_PROG_PNETCDF_CONFIG], [
   AC_REQUIRE([AC_PROG_EGREP])
 
   AC_CACHE_CHECK([if pnetcdf-config program is present],[ax_cv_prog_pnetcdf_config],[
-  AS_IF([pnetcdf-config --version 2>/dev/null | egrep -q '^PnetCDF '],
+  AS_IF([pnetcdf-config --version 2>/dev/null | egrep -q '^(PnetCDF|parallel-netcdf) '],
         [ax_cv_prog_pnetcdf_config=yes], [ax_cv_prog_pnetcdf_config=no])
       ])
   AS_IF([test "$ax_cv_prog_pnetcdf_config" = "yes"], [[$1]], [[$2]])

--- a/configure.ac
+++ b/configure.ac
@@ -363,7 +363,6 @@ AC_SUBST(NC_LIBS)
 if eval "test x$PNETCDF = x1"; then
   AX_PROG_PNETCDF_CONFIG([NCP_PREFIX=`pnetcdf-config --prefix`; NCPAUTO="yes"],
                          [NCP_PREFIX="${NETCDF}"; NCPAUTO="no"])
-  echo $NCPAUTO
 
   if eval "test x$NCPAUTO = xyes"; then
     CC=`pnetcdf-config --cc`


### PR DESCRIPTION
Hi again Graziano,

This change to recognize `pnetcdf-config` was necessary for me, and runs with `pnetcdf` made me save between 30% and 45% of the writing time with chemistry/aerosols, so I though it was useful. By the way, I did not find the way to add `PNETCDF` to the executables, would this be possible?

Cheers 